### PR TITLE
Remove git conflict text and fix two recipes showing at the same time.

### DIFF
--- a/pages/recipes.html
+++ b/pages/recipes.html
@@ -51,8 +51,7 @@
       <div class="col-md-8">
         <div class="tab-content" id="nav-tabContent">
           <!-- ::: CARD EXAMPLE OF A Recipe :::-->
-<<<<<<< HEAD
-          <div class="tab-pane active" id="gingerbread-men" role="tabpanel" aria-labelledby="gingerbread-mens">
+          <div class="tab-pane" id="gingerbread-men" role="tabpanel" aria-labelledby="gingerbread-mens">
             <div class="card mb-3" style="max-width: 670px;">
               <div class="row no-gutters">
                 <div class="col-md-12 col-lg-4">
@@ -520,9 +519,6 @@
           </div>
           <!-- ::: End of Pecan Pie Recipe ::: -->
 
-=======
-            
->>>>>>> upstream/master
         </div>
       </div>
     </div>


### PR DESCRIPTION
I noticed an issue with the recipes page. It was showing a git conflict message on the page and showing two recipes on one recipe card. I have attached two screenshots showcasing the issue and fixing the issue. 

**Screenshot of the issue.**

![recipeIssue](https://user-images.githubusercontent.com/37708829/66529844-a3911b00-eaca-11e9-9f74-90752e57c976.png)

**Screenshot of the page after the fix.**

![recipesFixed](https://user-images.githubusercontent.com/37708829/66529843-a3911b00-eaca-11e9-82b2-04509c4f0122.png)