### PR TITLE
Add The Elf on the Shelf to books page

### DIFF
--- a/pages/books.html
+++ b/pages/books.html
@@ -720,37 +720,39 @@
 
                 </div>
                 <!-- The Christmas Wish end-->
+
                 <!-- The Elf on the Shelf Start -->
-                <div class="tab-pane fade" id="elfontheshelf" role="tabpanel" aria-labelledby="list-settings-list">
-                    <div class="card mb-3" style="max-width: 670px;">
-                        <div class="row no-gutters">
-                            <div class="col-md-4">
-                                <img data-src="https://imgur.com/tGPdR0y"
-                                    class="card-img" alt="..." loading="lazy" />
-                            </div>
-                            <div class="col-md-8">
-                                <div class="card-body">
-                                    <h5 class="card-title">The Elf on the Shelf</h5>
-                                    <p class="card-text">
-                                        The Elf on the Shelf: A Christmas Tradition is a 2005 children's picture book,
-                                        written by Carol Aebersold and her daughter Chanda Bell, and illustrated by Coë
-                                        Steinwart. The book tells a Christmas-themed story, written in rhyme, that
-                                        explains how Santa Claus knows who is naughty and nice.<br>
-                                    </p>
-                                    <button class='btn-read-more'
-                                        onclick="window.open('https://youtu.be/muqdQuMeD58">
-                                        Read more
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                 <div aria-labelledby="list-settings-list" class="tab-pane fade" id="elfontheshelf"
+                     role="tabpanel">
+                     <div class="card mb-3" style="max-width: 670px;">
+                         <div class="row no-gutters">
+                             <div class="col-md-4">
+                                 <img alt="..." class="card-img"
+                                     data-src="https://i.imgur.com/tGPdR0y.jpg"
+                                     loading="lazy" />
+                             </div>
+                             <div class="col-md-8">
+                                 <div class="card-body">
+                                     <h5 class="card-title">The Elf on the Shelf</h5>
+                                     <p class="card-text">
+                                         The Elf on the Shelf: A Christmas Tradition is a 2005 children's picture book,
+                                         written by Carol Aebersold and her daughter Chanda Bell, and illustrated by Coë
+                                         Steinwart. The book tells a Christmas-themed story, written in rhyme, that
+                                         explains how Santa Claus knows who is naughty and nice.<br>
+                                     </p>
+                                     <button class='btn-read-more'
+                                         onclick="window.open('https://www.youtube.com/watch?v=muqdQuMeD58&feature=youtu.be')">
+                                         Read more
+                                     </button>
+                                 </div>
+                             </div>
+                         </div>
+                     </div>
+                 </div>
+                <!--The Elf on the Shelf End-->
 
-                </div>
-                <!-- The Elf on the Shelf End -->
-
-                <!-- START of new entry -->
-                <!-- END of new entry -->
+               <!-- START of new entry -->
+                 <!-- END of new entry -->
             </div>
         </div>
     </div>

--- a/pages/books.html
+++ b/pages/books.html
@@ -80,6 +80,8 @@
                    href="#thechristmassecret" id="list-settings-list" role="tab">The Christmas Secret</a>
                 <a aria-controls="settings" class="list-group-item list-group-item-action" data-toggle="list"
                    href="#polarExpress" id="list-settings-list" role="tab">The Polar Express</a>
+                <a aria-controls="settings" class="list-group-item list-group-item-action" data-toggle="list"
+                    href="#elfontheshelf" id="list-settings-list" role="tab">The Elf on the Shelf</a>
             </div>
         </div>
         <!-- :::END OF MENU TO FILTER FILMS :::-->
@@ -613,7 +615,7 @@
                     </div>
                 </div>
                 <!-- :: the Beach Hut END :: -->
-                
+
                 <!-- :: The Christmas Secret START :: -->
                 <div class="tab-pane fade" id="thechristmassecret" role="tabpanel" aria-labelledby="list-settings-list">
                     <div class="card mb-3" style="max-width: 670px;">
@@ -718,7 +720,35 @@
 
                 </div>
                 <!-- The Christmas Wish end-->
-                
+                <!-- The Elf on the Shelf Start -->
+                <div class="tab-pane fade" id="elfontheshelf" role="tabpanel" aria-labelledby="list-settings-list">
+                    <div class="card mb-3" style="max-width: 670px;">
+                        <div class="row no-gutters">
+                            <div class="col-md-4">
+                                <img data-src="https://imgur.com/tGPdR0y"
+                                    class="card-img" alt="..." loading="lazy" />
+                            </div>
+                            <div class="col-md-8">
+                                <div class="card-body">
+                                    <h5 class="card-title">The Elf on the Shelf</h5>
+                                    <p class="card-text">
+                                        The Elf on the Shelf: A Christmas Tradition is a 2005 children's picture book,
+                                        written by Carol Aebersold and her daughter Chanda Bell, and illustrated by Coë
+                                        Steinwart. The book tells a Christmas-themed story, written in rhyme, that
+                                        explains how Santa Claus knows who is naughty and nice.<br>
+                                    </p>
+                                    <button class='btn-read-more'
+                                        onclick="window.open('https://youtu.be/muqdQuMeD58">
+                                        Read more
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+                <!-- The Elf on the Shelf End -->
+
                 <!-- START of new entry -->
                 <!-- END of new entry -->
             </div>

--- a/pages/books.html
+++ b/pages/books.html
@@ -583,10 +583,6 @@
                                         </div>
                                     </div>
                                 </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
                 <!-- :: The Christmasaurus END :: -->
 
                 <!-- :: the Beach Hut START :: -->
@@ -722,14 +718,11 @@
                 <!-- The Christmas Wish end-->
 
                 <!-- The Elf on the Shelf Start -->
-                 <div aria-labelledby="list-settings-list" class="tab-pane fade" id="elfontheshelf"
-                     role="tabpanel">
+                 <div aria-labelledby="grinch-stole-list" class="tab-pane fade" id="elfontheshelf" role="tabpanel">
                      <div class="card mb-3" style="max-width: 670px;">
                          <div class="row no-gutters">
                              <div class="col-md-4">
-                                 <img alt="..." class="card-img"
-                                     data-src="https://i.imgur.com/tGPdR0y.jpg"
-                                     loading="lazy" />
+                                 <img alt="..." class="card-img" data-src="https://i.imgur.com/tGPdR0y.jpg" loading="lazy" />
                              </div>
                              <div class="col-md-8">
                                  <div class="card-body">
@@ -740,8 +733,7 @@
                                          Steinwart. The book tells a Christmas-themed story, written in rhyme, that
                                          explains how Santa Claus knows who is naughty and nice.<br>
                                      </p>
-                                     <button class='btn-read-more'
-                                         onclick="window.open('https://www.youtube.com/watch?v=muqdQuMeD58&feature=youtu.be')">
+                                     <button class='btn-read-more'        fade onclick="window.open('https://www.youtube.com/watch?v=muqdQuMeD58&feature=youtu.be')">
                                          Read more
                                      </button>
                                  </div>


### PR DESCRIPTION
This pull request also fixes the issue of the last cards on the page after the Christmasaurus book. Any cards after this entry appear at the bottom since that code closed divs prematurely. Deleted them and the cards now appear on the right at the top of the page.

![image](https://user-images.githubusercontent.com/38802201/66676462-8167dc00-ec35-11e9-9b66-f582744f8678.png)

