### PR TITLE
Bug Fix: Songs Page Sub Nav

### DIFF
--- a/pages/songs.html
+++ b/pages/songs.html
@@ -92,7 +92,7 @@
             <div class="col-8">
                 <div class="tab-content" id="nav-tabContent">
                     <!-- ::: CARD EXAMPLE OF A MOVIE :::-->
-                    <div aria-labelledby="grinch-stole-list" class="tab-pane active" id="last-christmas"
+                    <div aria-labelledby="grinch-stole-list" class="tab-pane active" 
                         role="tabpanel">
                         <div class="card mb-3" style="max-width: 670px;">
                             <div class="row no-gutters">
@@ -642,6 +642,8 @@
                                                         </div>
                                                     </div>
                                                 </div>
+                                            </div>
+                                        </div>
                                                 <!--End of Baby It's Cold Outside-->
 
                                                 <div aria-labelledby="grinch-stole-list" class="tab-pane fade"
@@ -1108,8 +1110,6 @@
                                                         </div>
                                                     </div>
                                                 </div>
-                                            </div>
-                                        </div>
                                         <!-- Happy Xmas (War is Over) ends here -->
                                         <div aria-labelledby="grinch-stole-list" class="tab-pane fade"
                                             id="have-yourself-a-merry-little-christmas" role="tabpanel">
@@ -1181,6 +1181,8 @@
                                                         </div>
                                                     </div>
                                                 </div>
+                                            </div>
+                                        </div>
                                                 <!--Have Yourself a Merry Little Christmas ends here-->
                                                 <div aria-labelledby="grinch-stole-list" class="tab-pane fade"
                                                     id="jingle-bell-rock" role="tabpanel">
@@ -1665,8 +1667,6 @@
                                                         </div>
                                                     </div>
                                                 </div>
-                                            </div>
-                                        </div>
                                         <!-- Merry Christmas Everyone ends here-->
                                         <div aria-labelledby="grinch-stole-list" class="tab-pane fade"
                                             id="rockin-around-the-christmas-tree" role="tabpanel">
@@ -1812,8 +1812,6 @@
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                </div>
                                 <!--Rockin' Around the Christmas Tree ends here-->
                                 <div aria-labelledby="rudolph-the-red-nosed-reindeer-song-list" class="tab-pane fade"
                                     id="rudolph-the-red-nosed-reindeer" role="tabpanel">
@@ -1894,6 +1892,8 @@
                                                 </div>
                                             </div>
                                         </div>
+                                    </div>
+                                </div>
                                         <!-- Rudolph the Red Nosed Reindeer ends here-->
                                         <div aria-labelledby="grinch-stole-list" class="tab-pane fade"
                                             id="run-rudolph-run" role="tabpanel">


### PR DESCRIPTION
The closing div placement for some card was incorrect. Like, one card had 5 opening div but only 2 closing div. This resulted the following card not to be working. I resolved the issue by removing those extra div. Moreover, the div (tab-pane active) had id of "last-christmas"  which resulted appending last-christmas song div whenever you click on another song you see the last christmas div below that card too.