### PR TITLE
With dark mode theme, card text on activities page were not visible

### DIFF
--- a/assets/css/activities.css
+++ b/assets/css/activities.css
@@ -27,3 +27,7 @@
     -ms-transform: translateY(-4px);
     transform: translateY(-4px);
 }
+/*with dark mode text is not visible hence added this explicit black color for cards*/
+.card-body{
+    color:black;
+}


### PR DESCRIPTION
Issue : When we toggle to dark mode, card texts on activities page are not visible.
I have fixed the above issue by adding a style for text color for activities page.