### PR TITLE
SANTAFIED text color and span correction

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -38,9 +38,6 @@ body {
 }
 
 /*navbar Starts*/
-.brand-color {
-    color: #ff4546;
-}
 
 .navbar {
     padding: 20px 16px;
@@ -152,6 +149,10 @@ a.navbar-brand > *{
   color:var(--text-color);
 }
 
+/* This is added to correct the color of FIED text on all the pages. */
+a.navbar-brand >.brand-color {
+    color: #ff4546;
+}
 
 /*Navbar END*/
 /*

--- a/pages/facts.html
+++ b/pages/facts.html
@@ -28,7 +28,7 @@
 <!-- :::NAV Starts ::: -->
 <div class="container">
     <nav class="navbar navbar-expand-lg navbar-light">
-        <a class="navbar-brand" href="../index.html"><i class="fa fa-cube"></i> SANTA<span
+        <a class="navbar-brand" href="../index.html"><i class="fa fa-cube"></i> <span>SANTA</span><span
                 class="brand-color">FIED</span></a>
         <div class="dropdown dropdown-container">
             <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle" data-toggle="dropdown"

--- a/pages/gifts.html
+++ b/pages/gifts.html
@@ -38,8 +38,8 @@
 <!-- :::NAV Starts ::: -->
 <div class="container">
     <nav class="navbar navbar-expand-lg navbar-light">
-        <a class="navbar-brand" href="../index.html"><i class="fa fa-cube"></i><span
-                class="brand-color"> SANTAFIED</span></a>
+        <a class="navbar-brand" href="../index.html"><i class="fa fa-cube"></i><span> SANTA</span></sapn><span
+                class="brand-color">FIED</span></a>
         <div class="dropdown dropdown-container">
             <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle" data-toggle="dropdown"
                href="#"

--- a/pages/gifts.html
+++ b/pages/gifts.html
@@ -38,7 +38,7 @@
 <!-- :::NAV Starts ::: -->
 <div class="container">
     <nav class="navbar navbar-expand-lg navbar-light">
-        <a class="navbar-brand" href="../index.html"><i class="fa fa-cube"></i><span> SANTA</span></sapn><span
+        <a class="navbar-brand" href="../index.html"><i class="fa fa-cube"></i><span> SANTA</span><span
                 class="brand-color">FIED</span></a>
         <div class="dropdown dropdown-container">
             <a aria-expanded="false" aria-haspopup="true" class="nav-link dropdown-toggle" data-toggle="dropdown"


### PR DESCRIPTION
1. In dark mode theme SANTA text was not visible on facts sheet
2. Updated the style class in main.css to make FIED of same color on all the pages. 
3. SANTAFIED text was inside the brand-color span on gifts page and due to that. Added a span for SANTA word.

