### PR TITLE
Fix container option of tns (tiny slider)

### DIFF
--- a/assets/js/carousel.js
+++ b/assets/js/carousel.js
@@ -1,12 +1,15 @@
-document.addEventListener("DOMContentLoaded", function () {
+document.addEventListener("DOMContentLoaded", function() {
   var slider = tns({
-    container: '#carousel',
+    container: ".container",
     items: 1,
-    mode: 'gallery',
+    mode: "gallery",
     center: true,
     nav: false,
     mouseDrag: true,
     speed: 1500,
-    controlsText: ['<i class="left-arrow fa fa-angle-left"></i>', '<i class="right-arrow fa fa-angle-right"></i>']
+    controlsText: [
+      '<i class="left-arrow fa fa-angle-left"></i>',
+      '<i class="right-arrow fa fa-angle-right"></i>'
+    ]
   });
 });


### PR DESCRIPTION
Now the tiny carousel can find the container "carousel" class.
Modified from container: "#carousel" to ".carousel".

Delete the weird console.error (can't read Length of undefined)