### PR TITLE
set z-index to auto for the herocontent div

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -5,6 +5,7 @@ section#hero-content {
     padding: 0;
     margin: 0;
     height: auto;
+    z-index: auto;
 }
 
 .carousel-item {


### PR DESCRIPTION
Change the z-index of the hero-content div so that the options on the navigation dropdown are not covered by it. Please accept my pull request