### PR TITLE
Added new rules to calendar.css to fix lower resolution issue

### DIFF
--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -36,6 +36,8 @@ body {font-family: Verdana, sans-serif;}
 
 /* Weekdays (Mon-Sun) */
 .weekdays {
+  display: flex;
+  flex-wrap: nowrap;
   margin: 0;
   padding: 10px 0;
   background-color:#ddd;
@@ -50,6 +52,8 @@ body {font-family: Verdana, sans-serif;}
 
 /* Days (1-31) */
 .days {
+  display: flex;
+  flex-wrap: wrap;
   padding: 10px 0;
   background: #eee;
   margin: 0;


### PR DESCRIPTION
Calendar had issues with properly displaying the weekdays and numbers at lower resolutions.
With the previous CSS rules and lower resolutions, Saturday would be placed under Sunday which would cause the numbers to be under the wrong days.