### PR TITLE
Centered the images and adjusted the margins for costume images at lower resolutions

### DIFF
--- a/pages/party-costumes.html
+++ b/pages/party-costumes.html
@@ -144,7 +144,7 @@
             >
               <div class="card mb-3" style="max-width: 670px;">
                 <div class="row no-gutters">
-                  <div class="col-md-12 col-lg-4">
+                  <div class="col-md-12 col-lg-4 text-center text-lg-left mt-2 mt-lg-0">
                     <img
                       alt="..."
                       class="card-img"
@@ -187,7 +187,7 @@
             >
               <div class="card mb-3" style="max-width: 670px;">
                 <div class="row no-gutters">
-                  <div class="col-md-12 col-lg-4">
+                  <div class="col-md-12 col-lg-4 text-center text-lg-left mt-2 mt-lg-0">
                     <img
                       alt="..."
                       class="card-img"
@@ -236,7 +236,7 @@
             >
               <div class="card mb-3" style="max-width: 670px;">
                 <div class="row no-gutters">
-                  <div class="col-md-12 col-lg-4">
+                  <div class="col-md-12 col-lg-4 text-center text-lg-left mt-2 mt-lg-0">
                     <img
                       alt="..."
                       class="card-img"
@@ -280,7 +280,7 @@
             >
               <div class="card mb-3" style="max-width: 670px;">
                 <div class="row no-gutters">
-                  <div class="col-md-12 col-lg-4">
+                  <div class="col-md-12 col-lg-4 text-center text-lg-left mt-2 mt-lg-0">
                     <img
                       alt="..."
                       class="card-img"
@@ -323,7 +323,7 @@
             >
               <div class="card mb-3" style="max-width: 670px;">
                 <div class="row no-gutters">
-                  <div class="col-md-12 col-lg-4">
+                  <div class="col-md-12 col-lg-4 text-center text-lg-left mt-2 mt-lg-0">
                     <img
                       alt="..."
                       class="card-img"
@@ -369,7 +369,7 @@
             >
               <div class="card mb-3" style="max-width: 670px;">
                 <div class="row no-gutters">
-                  <div class="col-md-12 col-lg-4">
+                  <div class="col-md-12 col-lg-4 text-center text-lg-left mt-2 mt-lg-0">
                     <img
                       alt="..."
                       class="card-img"


### PR DESCRIPTION
At lower resolutions, the image has no whitespace between the image and the card border; giving it some whitespace and centering it made it look more visually appealing.