### PR TITLE
🐛 FIX: fixed navbar-brand color for "santa" in dark mode on books page

### DIFF
--- a/pages/books.html
+++ b/pages/books.html
@@ -40,7 +40,7 @@
     <div class="container">
       <nav class="navbar navbar-expand-lg navbar-light">
         <a class="navbar-brand" href="../index.html"
-          ><i class="fa fa-cube"></i> SANTA<span class="brand-color"
+          ><i class="fa fa-cube"></i> <span>SANTA</span><span class="brand-color"
             >FIED</span
           ></a
         >


### PR DESCRIPTION
When switching to "dark mode", I realized that the text for the HTML-Element navbar "SantaFied" didn't change the text "Santa" from black to white.
That means, that the text "Santa" vanishes.

I realized that the other pages surround the text "Santa" with a HTML span element, thus I added one.
Now switching to dark mode on the page for books shows the complete brand text.