### PR TITLE
Fix#591 calendar image disappears on card hover

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
         </a>
 
         <a id="nav-item" href="pages/calendar.html" class="card m-2 shadow-sm d-flex align-items-center justify-content-center">
-          <div class="card-body card-body-device">
+          <div class="card-body">
             <div class="card-image-placeholder device" id="calendar">
               <header>
                 <div class="header-bar"></div>


### PR DESCRIPTION
Removed one class that made the image display set to "none". Now it should be OK.